### PR TITLE
Changed notification msg domain host

### DIFF
--- a/tl-services/src/main/java/org/egov/tl/util/BPANotificationUtil.java
+++ b/tl-services/src/main/java/org/egov/tl/util/BPANotificationUtil.java
@@ -31,7 +31,7 @@ public class BPANotificationUtil {
 
     private Producer producer;
 
-    @Value("${egov.host.domain.name}")
+    @Value("${egov.ui.app.host}")
     private String egovhost;
 
     @Value("${egov.common.pay.endpoint}")


### PR DESCRIPTION
As we are using this URL in notification message this host is not getting changed for each environment(dev/qa) because of the property **egov.host.domain.name** value, so changed this to  **egov.ui.app.host** so that the domain url will get updated as per the environment.