### PR TITLE
Fixed the landsearch with multi owner issue

### DIFF
--- a/land-services/src/main/java/org/egov/land/service/LandService.java
+++ b/land-services/src/main/java/org/egov/land/service/LandService.java
@@ -84,6 +84,7 @@ public class LandService {
 		landValidator.validateSearch(requestInfo, criteria);
 		if (criteria.getMobileNumber() != null) {
 			landInfo = getLandFromMobileNumber(criteria, requestInfo);
+			landInfo = getMultiOwnerRecords(landInfo, requestInfo);
 		} else {
 			List<String> roles = new ArrayList<>();
 			for (Role role : requestInfo.getUserInfo().getRoles()) {
@@ -97,6 +98,18 @@ public class LandService {
 			log.debug("Received final landInfo response in service call..");			
 		}
 		return landInfo;
+	}
+	
+	private List<LandInfo> getMultiOwnerRecords(List<LandInfo> landInfos, RequestInfo requestInfo) {
+
+		List<String> landIds = new ArrayList<String>();
+		for (LandInfo li : landInfos) {
+			landIds.add(li.getId());
+		}
+		LandSearchCriteria criteria = LandSearchCriteria.builder().tenantId(landInfos.get(0).getTenantId()).ids(landIds)
+				.build();
+		landInfos = getLandWithOwnerInfo(criteria, requestInfo);
+		return landInfos;
 	}
 	
 	private List<LandInfo> getLandFromMobileNumber(LandSearchCriteria criteria, RequestInfo requestInfo) {


### PR DESCRIPTION
In MultiOnwers case, When we search landInfo using mobileNumber we are getting landInfo record with single ownerDetails. Fixed the issue by searching the landInfo details by mobileNumber and then by Land Id. so that, we will get all the ownerDetails inside the landInfo object.