### PR TITLE
Issue #71 Jurisdiction based validation for property update

### DIFF
--- a/property-services/src/main/java/org/egov/pt/models/Property.java
+++ b/property-services/src/main/java/org/egov/pt/models/Property.java
@@ -98,6 +98,9 @@ public class Property extends PropertyInfo {
 	
 	@JsonProperty("auditDetails")
 	private AuditDetails auditDetails;
+	
+	@JsonProperty("locality")
+	private Locality locality;
 
 	@JsonProperty("workflow")
 	@DiffIgnore

--- a/property-services/src/main/java/org/egov/pt/models/hrms/Employee.java
+++ b/property-services/src/main/java/org/egov/pt/models/hrms/Employee.java
@@ -1,0 +1,51 @@
+package org.egov.pt.models.hrms;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.egov.pt.models.user.User;
+
+import lombok.Data;
+
+@Data
+public class Employee {
+
+	  private Long id;
+
+	    private String uuid;
+
+	    private String code;
+
+	    private String employeeStatus;
+
+	    private String employeeType;
+
+	    private Long dateOfAppointment;
+
+	    private List<Locality> jurisdictions = new ArrayList<>();
+
+	    private List<List> assignments = new ArrayList<>();
+
+	    private List<List> serviceHistory = new ArrayList<>();
+
+
+	    private Boolean IsActive;
+
+	    private List<String> education = new ArrayList<>();
+
+	    private List<String> tests = new ArrayList<>();
+
+	    private String tenantId;
+
+	    private List<String> documents = new ArrayList<>();
+
+	    private List<String> deactivationDetails = new ArrayList<>();
+
+	    private List<String> reactivationDetails = new ArrayList<>();
+
+	    private String auditDetails;
+
+	    private Boolean reActivateEmployee;
+	    
+	    private User user;
+}

--- a/property-services/src/main/java/org/egov/pt/models/hrms/HRMSResponse.java
+++ b/property-services/src/main/java/org/egov/pt/models/hrms/HRMSResponse.java
@@ -1,0 +1,13 @@
+package org.egov.pt.models.hrms;
+
+import java.util.List;
+
+import org.egov.common.contract.response.ResponseInfo;
+
+import lombok.Data;
+
+@Data
+public class HRMSResponse {
+    private ResponseInfo responseInfo;
+    private List<Employee> employees;
+}

--- a/property-services/src/main/java/org/egov/pt/models/hrms/Locality.java
+++ b/property-services/src/main/java/org/egov/pt/models/hrms/Locality.java
@@ -1,0 +1,27 @@
+package org.egov.pt.models.hrms;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Locality {
+    private String code;
+    private String name;
+    private String label;
+    private Double latitude;
+    private Double longitude;
+    private String area;
+    private List<Locality> children;
+    private String materializedPath;
+
+   
+}

--- a/property-services/src/main/java/org/egov/pt/service/HrmsService.java
+++ b/property-services/src/main/java/org/egov/pt/service/HrmsService.java
@@ -1,0 +1,70 @@
+package org.egov.pt.service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.egov.common.contract.request.RequestInfo;
+import org.egov.common.contract.request.Role;
+import org.egov.pt.models.hrms.HRMSResponse;
+import org.egov.pt.repository.ServiceRequestRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class HrmsService {
+
+	@Autowired
+	private ServiceRequestRepository serviceRequestRepository;
+
+	@Value("${egov.hrms.host}")
+	private String hrmsHost;
+
+	@Value("${egov.hrms.search.path}")
+	private String hrmsSearchEndpoint;
+	
+	@Autowired
+	ObjectMapper objectMapper;
+
+	/**
+	 * Performs an API call to the searchHRMS endpoint.
+	 *
+	 * @param requestInfo RequestInfo for the API call
+	 * @param tenantId    Tenant ID
+	 * @param roles       List of roles
+	 * @param boundary    Boundary parameter
+	 * @return Response from the HRMS searchHRMS endpoint
+	 */
+	public HRMSResponse searchHRMS(RequestInfo requestInfo, String tenantId, List<Role> roles, String boundary) {
+		// Create the API request body
+		String requestBody = "{\"RequestInfo\":" + requestInfo.toString() + "}"; 
+		
+		 List<String> roleCodes = roles.stream()
+		            .map(Role::getCode)
+		            .collect(Collectors.toList());
+		
+		 String rolesString = String.join(",", roleCodes);
+		// Create the API URL
+		String apiUrl = hrmsHost + hrmsSearchEndpoint + "?tenantId=" + tenantId + "&roles=" + rolesString + "&boundary="
+				+ boundary; // Modify as needed
+
+		try {
+			
+			Optional<Object> response = serviceRequestRepository.fetchResult(new StringBuilder(apiUrl), requestBody);
+			if (response.isPresent()) {
+	            String responseString = response.get().toString();
+	            // Parse the response and map it to HRMSResponse object
+	            HRMSResponse hrmsResponse = objectMapper.readValue(responseString, HRMSResponse.class);
+	            return hrmsResponse;
+	        } else {  
+	            return null; 
+	        }
+			
+		} catch (Exception e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
+
+}

--- a/property-services/src/main/resources/application.properties
+++ b/property-services/src/main/resources/application.properties
@@ -128,6 +128,12 @@ egov.localization.context.path=/localization/messages/v1
 egov.localization.search.endpoint=/_search
 egov.localization.statelevel=true
 
+#jurisdiction level flag
+egov.jurisdiction.enable=false
+
+#hrms-service
+egov.hrms.host=http://127.0.0.1:9999
+egov.hrms.search.path=/egov-hrms/employees/_search
 
 #mdms urls
 egov.mdms.host=https://dev.digit.org


### PR DESCRIPTION
Made the following changes to check if the assessor/assignee is in the jurisdiction of the property

-> Added HrmsService to fetch employee data in a particular jurisdiction
-> Added appropriate data models - Employee, HRMSResponse and Locality to store the fetched response
-> Modified Property model to get Locality as a field
-> Modified PropertyValidator to validate based on juridiction at 2 levels while updating property. First for the assessor to be in the same jurisdiction and the assignee to be in the same jurisdiction as well
-> Modified application.properties for jurisdiction flag and hrms endpoint